### PR TITLE
Removed copying config files and replaced with a reference

### DIFF
--- a/master.sh
+++ b/master.sh
@@ -1,12 +1,7 @@
 #https://repo.saltstack.com/#ubuntu
 apt-get install -y salt-master salt-api
 
-cp /vagrant/configs/fileroots.conf /etc/salt/master.d/fileroots.conf
-cp /vagrant/configs/reactor.conf /etc/salt/master.d/reactor.conf
-cp /vagrant/configs/auth.conf /etc/salt/master.d/auth.conf
-cp /vagrant/configs/api.conf /etc/salt/master.d/api.conf
-cp /vagrant/configs/returner.conf /etc/salt/master.d/returner.conf
-cp /vagrant/configs/gitfs.conf /etc/salt/master.d/gitfs.conf
+sed -i "\$ainclude:\n\ \ - /vagrant/configs/*" /etc/salt/master
 
 service salt-master restart
 


### PR DESCRIPTION
This will keep both config and state, pillar etc. out of the VM for easy editing.
Tested where I changed gitfs references and rebooted the `salt-master` service which picked up on the changes.